### PR TITLE
fix: example items' end border is visible on content overflow

### DIFF
--- a/examples/basic/src/Item.tsx
+++ b/examples/basic/src/Item.tsx
@@ -18,7 +18,13 @@ function Item(props: ItemProps) {
   return (
     <div ref={setNodeRef} style={itemStyle} {...listeners} {...attributes}>
       <div style={itemContentStyle}>
-        <div style={{ border: "1px solid white", width: "100%" }}>
+        <div
+          style={{
+            border: "1px solid white",
+            width: "100%",
+            overflow: "hidden",
+          }}
+        >
           {props.children}
         </div>
       </div>

--- a/examples/external/src/Item.tsx
+++ b/examples/external/src/Item.tsx
@@ -22,7 +22,13 @@ function Item(props: ItemProps) {
   return (
     <div ref={setNodeRef} style={itemStyle} {...listeners} {...attributes}>
       <div style={itemContentStyle}>
-        <div style={{ border: "1px solid white", width: "100%" }}>
+        <div
+          style={{
+            border: "1px solid white",
+            width: "100%",
+            overflow: "hidden",
+          }}
+        >
           {props.children}
         </div>
       </div>

--- a/examples/sortable/src/Item.tsx
+++ b/examples/sortable/src/Item.tsx
@@ -22,7 +22,13 @@ function Item(props: ItemProps) {
   return (
     <div ref={setNodeRef} style={itemStyle} {...listeners} {...attributes}>
       <div style={itemContentStyle}>
-        <div style={{ border: "1px solid white", width: "100%" }}>
+        <div
+          style={{
+            border: "1px solid white",
+            width: "100%",
+            overflow: "hidden",
+          }}
+        >
           {props.children}
         </div>
       </div>

--- a/examples/timeaxis/src/Item.tsx
+++ b/examples/timeaxis/src/Item.tsx
@@ -18,7 +18,13 @@ function Item(props: ItemProps) {
   return (
     <div ref={setNodeRef} style={itemStyle} {...listeners} {...attributes}>
       <div style={itemContentStyle}>
-        <div style={{ border: "1px solid white", width: "100%" }}>
+        <div
+          style={{
+            border: "1px solid white",
+            width: "100%",
+            overflow: "hidden",
+          }}
+        >
           {props.children}
         </div>
       </div>

--- a/examples/virtual/src/Item.tsx
+++ b/examples/virtual/src/Item.tsx
@@ -18,7 +18,13 @@ function Item(props: ItemProps) {
   return (
     <div ref={setNodeRef} style={itemStyle} {...listeners} {...attributes}>
       <div style={itemContentStyle}>
-        <div style={{ border: "1px solid white", width: "100%" }}>
+        <div
+          style={{
+            border: "1px solid white",
+            width: "100%",
+            overflow: "hidden",
+          }}
+        >
           {props.children}
         </div>
       </div>


### PR DESCRIPTION
In the examples, when the content of an item overflows, the "end" border (right border in the examples) disappears.
Added `overflow: "hidden"` to the content's wrapper div.