### PR TITLE
Fix link to full code of example in docs

### DIFF
--- a/docs/v2/documentation/zoom-and-pan/performance.md
+++ b/docs/v2/documentation/zoom-and-pan/performance.md
@@ -215,6 +215,6 @@ export function useDebounce<T>(value: T, delay = 500) {
 
 In this example, You can play around with difference modes and feel the difference between them.&#x20;
 
-[Click here to see the full code](../../../examples/performance/src/App.tsx)
+[Click here to see the full code](../../../../examples/performance/src/App.tsx)
 
 {% embed url="https://dnd-timeline-performance.vercel.app" %}


### PR DESCRIPTION
Currently resolved to:
https://github.com/samuelarbibe/dnd-timeline/blob/main/docs/examples/performance/src/App.tsx (mind the **docs**)

Correct link:
https://github.com/samuelarbibe/dnd-timeline/blob/main/examples/performance/src/App.tsx

Thanks for the awesome project, looks very promising!