### PR TITLE
fix: store timeframe ref in useState

### DIFF
--- a/packages/dnd-timeline/src/hooks/useElementRef.tsx
+++ b/packages/dnd-timeline/src/hooks/useElementRef.tsx
@@ -1,35 +1,34 @@
-import { useCallback, useRef, useState } from "react";
+import { type MutableRefObject, useCallback, useRef, useState } from "react";
 import ResizeObserver from "resize-observer-polyfill";
 
 export default function useElementRef() {
-	const ref = useRef<HTMLElement | null>(null);
+	const [ref, setRef] = useState<MutableRefObject<HTMLElement | null>>({
+		current: null,
+	});
 	const [width, setWidth] = useState(0);
 	const [direction, setDirection] = useState<CanvasDirection>("ltr");
 
 	const resizeObserver = useRef<ResizeObserver>();
 
-	const setRef = useCallback((element: HTMLElement | null) => {
-		if (element !== ref.current) {
-			resizeObserver.current?.disconnect();
+	const onSetRef = useCallback((element: HTMLElement | null) => {
+		resizeObserver.current?.disconnect();
 
-			if (element) {
-				resizeObserver.current = new ResizeObserver((entries) => {
-					for (const entry of entries) {
-						setWidth(entry.contentRect.width);
-					}
-				});
+		if (element) {
+			resizeObserver.current = new ResizeObserver((entries) => {
+				setWidth(entries[0].contentRect.width);
+			});
 
-				resizeObserver.current.observe(element);
+			resizeObserver.current.observe(element);
 
-				setDirection(getComputedStyle(element).direction as CanvasDirection);
-			}
+			setDirection(getComputedStyle(element).direction as CanvasDirection);
 		}
-		ref.current = element;
+
+		setRef({ current: element });
 	}, []);
 
 	return {
 		ref,
-		setRef,
+		setRef: onSetRef,
 		width,
 		direction,
 	};


### PR DESCRIPTION
The timeframe ref is used internally and externally to perform all kinds of calculations, and to trigger width and direction updates according to the timeframe element if needed.  
  
### The problem   
The current the ref is saved using a `useRef`, meaning there is no way to detect changes in the ref after an unmount.  
This may be needed in situations where the timeline is mounted and unmounted in loading states.  
When re-mounted, many listeners will no-longer work.  
  
### The solution
The timeline ref is now saved in a `useState`, and changes to that state can be easily listened to by any event listener, `useEffect`, `useCallback` etc.  
The timeline ref is now a part of the conventional react lifecycle.