### PR TITLE
feat: add capability to control resizing animation

### DIFF
--- a/packages/dnd-timeline/src/types/item.ts
+++ b/packages/dnd-timeline/src/types/item.ts
@@ -25,6 +25,7 @@ export interface UseItemProps
 	onResizeEnd?: (event: ResizeEndEvent) => void;
 	onResizeMove?: (event: ResizeMoveEvent) => void;
 	onResizeStart?: (event: ResizeStartEvent) => void;
+	calcNewSan?: CalculateNewSpan;
 }
 
 interface ItemDataBase extends Data {
@@ -48,3 +49,10 @@ export interface DragActiveItem extends Active {
 export interface ResizeActiveItem extends Omit<Active, "rect"> {
 	data: MutableRefObject<ResizeItemData>;
 }
+
+export interface CalculateNewSpanArgs {
+	span: Span;
+	direction: DragDirection;
+	deltaX: number;
+}
+export type CalculateNewSpan = (args: CalculateNewSpanArgs) => Span;


### PR DESCRIPTION
Related to #44 

Hi, let me suggest to add the feature to control resize animation.
Currently, `dnd-timeline` doesn't allow us to control the resize animation during pointer move, it only allows when `onResizeEnd`. 
So user can resize invalid and they notice it on `pointerup` event.
I needed to control resize only by specific tick (in my case, 1 day tick) and I implemented it.
The demo movie is here: 

https://github.com/user-attachments/assets/81e7e27d-308c-4d2c-8a7d-39aa7ff9b96a

My code is here:
```ts
const tick = hoursToMilliseconds(24);
const dailyResizer: CalculateNewSpan = ({ span, direction ,deltaX }) => {
  if (direction === 'start') {
    // omit
  } else {
    const threshold = 0.5 * tick;
    const newEnd = span.end + deltaX;
    const prevTarget = Math.floor(newEnd / tick) * tick;
    const nextTarget = Math.ceil(newEnd / tick) * tick;

    return {
      ...span,
      end: Math.max(
        span.start,
        prevTarget + threshold <= newEnd ? nextTarget : prevTarget
      ),
    };
  }
}

export function Item(props) {
  const { /* hook return */ } = useItem({
    id: props.id,
    span: props.span,
    calcNewSpan: dailyResizer,
  })
}
```

Thank you for your great library and review!