### PR TITLE
fix: memoize onPanEnd and send it the the full timelineBag

### DIFF
--- a/packages/dnd-timeline/src/utils/panStrategies.ts
+++ b/packages/dnd-timeline/src/utils/panStrategies.ts
@@ -1,15 +1,15 @@
 import { useLayoutEffect, useRef } from "react";
 
-import type { OnPanEnd, PanEndEvent } from "../types";
+import type { OnPanEnd, PanEndEvent, TimelineBag } from "../types";
 
 export type UsePanStrategy = (
-	timelineRef: React.MutableRefObject<HTMLElement | null>,
+	timelineBag: TimelineBag,
 	onPanEnd: OnPanEnd,
 ) => void;
 
-export const useWheelStrategy: UsePanStrategy = (timelineRef, onPanEnd) => {
+export const useWheelStrategy: UsePanStrategy = (timelineBag, onPanEnd) => {
 	useLayoutEffect(() => {
-		const element = timelineRef.current;
+		const element = timelineBag.timelineRef.current;
 		if (!element) return;
 
 		const pointerWheelHandler = (event: WheelEvent) => {
@@ -34,14 +34,14 @@ export const useWheelStrategy: UsePanStrategy = (timelineRef, onPanEnd) => {
 		return () => {
 			element.removeEventListener("wheel", pointerWheelHandler);
 		};
-	}, [onPanEnd, timelineRef]);
+	}, [onPanEnd, timelineBag.timelineRef]);
 };
 
-export const useDragStrategy: UsePanStrategy = (timelineRef, onPanEnd) => {
+export const useDragStrategy: UsePanStrategy = (timelineContext, onPanEnd) => {
 	const lastDragX = useRef<number | null>(null);
 
 	useLayoutEffect(() => {
-		const element = timelineRef.current;
+		const element = timelineContext.timelineRef.current;
 		if (!element) return;
 
 		const pointerWheelHandler = (event: WheelEvent) => {
@@ -66,10 +66,10 @@ export const useDragStrategy: UsePanStrategy = (timelineRef, onPanEnd) => {
 		return () => {
 			element.removeEventListener("wheel", pointerWheelHandler);
 		};
-	}, [onPanEnd, timelineRef]);
+	}, [onPanEnd, timelineContext.timelineRef]);
 
 	useLayoutEffect(() => {
-		const element = timelineRef.current;
+		const element = timelineContext.timelineRef.current;
 		if (!element) return;
 
 		const pointerdownHandler = (event: MouseEvent) => {
@@ -108,5 +108,5 @@ export const useDragStrategy: UsePanStrategy = (timelineRef, onPanEnd) => {
 			element.removeEventListener("pointermove", pointermoveHandler);
 			element.removeEventListener("pointerleave", pointerupHandler);
 		};
-	}, [onPanEnd, timelineRef]);
+	}, [onPanEnd, timelineContext.timelineRef]);
 };


### PR DESCRIPTION
While responding to #72, and trying to implement a custom pan strategy, I noticed 2 problems:
1. The context given to that hook, `timelineRef`, lacks data and context that may be very helpful. This could be easily solved by calling the `useTimelineContext` internally, but I noticed that I could pass the full `timelineBag`, that contains the full timeline context, Without hurting performance.
2. The `onPadEnd` callback was improperly memoized, and was re-generated every time `range` changed. This means that every time `onPanEnd` was called, it was re-generated, `useEffect`s would re-initialize, etc....

This PR fixes these 2 problems.