### PR TITLE
feat: add resizeHandleWidth prop to item

### DIFF
--- a/examples/basic/src/index.css
+++ b/examples/basic/src/index.css
@@ -11,6 +11,7 @@
 	text-rendering: optimizeLegibility;
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
+	user-select: none;
 }
 
 #root {

--- a/packages/dnd-timeline/src/hooks/useItem.tsx
+++ b/packages/dnd-timeline/src/hooks/useItem.tsx
@@ -46,11 +46,13 @@ export default function useItem(props: UseItemProps) {
 		onResizeMove,
 		onResizeStart,
 		direction,
-		resizeHandleWidth,
+		resizeHandleWidth: contextResizeHandleWidth,
 		valueToPixels,
 		getSpanFromDragEvent,
 		getSpanFromResizeEvent,
 	} = useTimelineContext();
+
+	const resizeHandleWidth = props.resizeHandleWidth ?? contextResizeHandleWidth;
 
 	const propsOnResizeEnd = props.onResizeEnd;
 	const propsOnResizeStart = props.onResizeStart;

--- a/packages/dnd-timeline/src/types/item.ts
+++ b/packages/dnd-timeline/src/types/item.ts
@@ -22,6 +22,7 @@ export interface ItemDefinition {
 export interface UseItemProps
 	extends Pick<ItemDefinition, "id" | "span" | "disabled"> {
 	data?: object;
+	resizeHandleWidth?: number;
 	onResizeEnd?: (event: ResizeEndEvent) => void;
 	onResizeMove?: (event: ResizeMoveEvent) => void;
 	onResizeStart?: (event: ResizeStartEvent) => void;


### PR DESCRIPTION
✨ Add `resizeHandleWidth` Prop to `useItem` Hook

This PR adds support for disabling item resizing on a per-item basis by introducing a new resizeHandleWidth prop to the useItem hook.

✅ Changes
	•	Added resizeHandleWidth?: number option to useItem hook.
	•	When resizeHandleWidth is set to 0, the item becomes non-resizable.
	•	Default behavior (when undefined) remains unchanged.

📌 Motivation

Resolves [#74](https://github.com/samuelarbibe/dnd-timeline/issues/74) — some use cases require non-resizable items. This change allows users to opt-out of resizing with a single prop.

Documentation will be updated as well.