### PR TITLE
fix: suppress synthetic click after item resize

### DIFF
--- a/packages/dnd-timeline/src/hooks/useItem.tsx
+++ b/packages/dnd-timeline/src/hooks/useItem.tsx
@@ -187,6 +187,21 @@ export default function useItem(props: UseItemProps) {
 		const pointerupHandler = (event: globalThis.PointerEvent) => {
 			if (!dragStartX.current || !draggableProps.node.current) return;
 
+			// Suppress the synthetic click that browsers fire after pointerup on the
+			// same element. @dnd-kit/core's PointerSensor does this for drags; replicate
+			// for resize so consumers' onClick handlers don't fire unexpectedly.
+			if (dragDeltaXRef.current !== 0) {
+				const suppressClick = (e: Event) => e.stopPropagation();
+				document.addEventListener("click", suppressClick, {
+					capture: true,
+					once: true,
+				});
+				setTimeout(
+					() => document.removeEventListener("click", suppressClick, true),
+					50,
+				);
+			}
+
 			onResizeEndCallback({
 				activatorEvent: event,
 				delta: {


### PR DESCRIPTION
## Summary

Browsers fire a synthetic `click` event on an element after `pointerdown` + `pointerup` on the same target. `@dnd-kit/core`'s `PointerSensor` handles this for drags by adding a capture-phase click listener that calls `stopPropagation()` after drag activation, and removes it 50ms later in `detach()`.

Since `useItem` handles resize independently (bypassing the sensor via its own `window` pointermove/pointerup listeners), dnd-kit's click suppression never fires for resize operations. This causes unintended side effects for consumers who have `onClick` handlers on their timeline items (e.g. opening a detail drawer on release).

## Fix

Add the same click suppression pattern in the resize `pointerupHandler` when `dragDeltaXRef.current !== 0` (actual movement occurred). This mirrors exactly what `@dnd-kit/core`'s `PointerSensor` does in `handleStart()` / `detach()`:

```typescript
if (dragDeltaXRef.current !== 0) {
    const suppressClick = (e: Event) => e.stopPropagation();
    document.addEventListener("click", suppressClick, { capture: true, once: true });
    setTimeout(() => document.removeEventListener("click", suppressClick, true), 50);
}
```

- Closes #90